### PR TITLE
ozwcp needs to run from the installed directory

### DIFF
--- a/ozw-controlpanel/Dockerfile
+++ b/ozw-controlpanel/Dockerfile
@@ -9,51 +9,25 @@ FROM centos:centos7 as builder
 # File Author / Maintainer
 MAINTAINER Justin Hammond
 
-WORKDIR /etc/yum.repos.d/
-
-
 # Add the package verification key
-#RUN yum install wget -y && wget http://mirror.my-ho.st/Downloads/OpenZWave%3A/Devel/CentOS_CentOS-7/OpenZWave%3ADevel.repo
 COPY /files/*.repo /etc/yum.repos.d/
 
 # Update the repository sources list
 RUN yum update -y && yum install epel-release -y && yum groupinstall 'Development Tools' -y 
 RUN yum install tinyxml-devel libmicrohttpd-devel libopenzwave-devel gnutls-devel systemd-devel -y
 
-
-################## BEGIN INSTALLATION ######################
-# Install MongoDB Following the Instructions at MongoDB Docs
-# Ref: http://docs.mongodb.org/manual/tutorial/install-mongodb-on-ubuntu/
-
-
 RUN adduser ozwcp_user
-RUN usermod -a -G dialout ozwcp_user
-RUN usermod -a -G games ozwcp_user
-
 USER ozwcp_user
+
 ENV HOME /home/ozwcp_user
 
 WORKDIR	$HOME
-
 RUN git clone https://github.com/OpenZWave/open-zwave-control-panel.git
 
-WORKDIR $HOME/open-zwave-control-panel
-
-COPY /files/Makefile $HOME/open-zwave-control-panel/
-#ADD https://raw.githubusercontent.com/OpenZWave/open-zwave/master/cpp/tinyxml/tinyxml.h $HOME/open-zwave-control-panel/
-#ADD https://raw.githubusercontent.com/OpenZWave/open-zwave/master/cpp/tinyxml/tinystr.h $HOME/open-zwave-control-panel/
-
-#USER root
-#RUN chown ozwcp_user $HOME/open-zwave-control-panel/tiny*
-USER ozwcp_user
-
+WORKDIR open-zwave-control-panel
+COPY /files/Makefile .
 
 RUN make
-
-
-USER root
-RUN yum grouperase 'Development Tools' -y
-RUN yum erase libmicrohttpd-devel libopenzwave-devel systemd-container-devel -y
 
 FROM centos:centos7 as final
 
@@ -63,17 +37,18 @@ MAINTAINER Justin Hammond
 RUN adduser ozwcp_user
 RUN usermod -a -G dialout ozwcp_user
 RUN usermod -a -G games ozwcp_user
+
 COPY /files/*.repo /etc/yum.repos.d/
 RUN yum install epel-release -y && yum install tinyxml libmicrohttpd libopenzwave gnutls -y
 
-USER ozwcp_user
 ENV HOME /home/ozwcp_user
+WORKDIR	$HOME/open-zwave-control-panel
 
-WORKDIR	$HOME
+COPY --from=builder --chown=ozwcp_user:ozwcp_user $HOME/open-zwave-control-panel .
+RUN chown ozwcp_user:ozwcp_user .
 
-COPY --from=builder /home/ozwcp_user/open-zwave-control-panel /home/ozwcp_user/open-zwave-control-panel/
-
+USER ozwcp_user
 EXPOSE 8008
-ENTRYPOINT ["/home/ozwcp_user/open-zwave-control-panel/ozwcp", "-p 8008"]
+ENTRYPOINT ["./ozwcp", "-p 8008"]
 
 


### PR DESCRIPTION
Fixes #3 

Built locally with `sudo docker build -t ozwcp .`

Ran with `sudo docker run -d --name="ozw-cp" -p 8008:8008 --device=/dev/serial/by-id/usb-0658_0200_E2061B02-4A02-0114-3A06-FD1871291660-if00:/dev/zwave ozwcp`.

The Web UI loaded without error and I could perform operations on the network.